### PR TITLE
Add services to tailscale internal network, remove dashboard

### DIFF
--- a/services/alertmanager/service.yml
+++ b/services/alertmanager/service.yml
@@ -3,10 +3,13 @@ kind: Service
 metadata:
   name: alertmanager
   namespace: monitoring
+  annotations:
+    tailscale.com/expose: 'true'
+    tailscale.com/hostname: ct-prod-alertmanager
 spec:
-  clusterIP: None
   selector:
     app: alertmanager
   ports:
-    - name: alertmanager
-      port: 9093
+    - port: 9093
+      name: alertmanager
+      targetPort: alertmanager

--- a/services/grafana/configs/grafana.ini
+++ b/services/grafana/configs/grafana.ini
@@ -1,6 +1,6 @@
 [server]
-root_url = https://monitoring.cash-track.app
-domain = monitoring.cash-track.app
+root_url = http://ct-prod-grafana
+domain = ct-prod-grafana
 enforce_domain = true
 enable_gzip = true
 

--- a/services/grafana/service.yml
+++ b/services/grafana/service.yml
@@ -1,3 +1,4 @@
+# To be deleted
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -23,6 +24,9 @@ kind: Service
 metadata:
   name: grafana
   namespace: monitoring
+  annotations:
+    tailscale.com/expose: 'true'
+    tailscale.com/hostname: ct-prod-grafana
 spec:
   type: ClusterIP
   selector:

--- a/services/mysql/service.yml
+++ b/services/mysql/service.yml
@@ -3,9 +3,13 @@ kind: Service
 metadata:
   name: mysql
   namespace: cash-track
+  annotations:
+    tailscale.com/expose: 'true'
+    tailscale.com/hostname: ct-prod-mysql
 spec:
-  clusterIP: None
   selector:
     app: mysql
   ports:
     - port: 3306
+      name: mysql
+      targetPort: mysql

--- a/services/prometheus/service.yml
+++ b/services/prometheus/service.yml
@@ -3,9 +3,13 @@ kind: Service
 metadata:
   name: prometheus
   namespace: monitoring
+  annotations:
+    tailscale.com/expose: 'true'
+    tailscale.com/hostname: ct-prod-prometheus
 spec:
-  clusterIP: None
   selector:
     app: prometheus
   ports:
     - port: 9090
+      name: prometheus
+      targetPort: prometheus

--- a/services/redis/service.yml
+++ b/services/redis/service.yml
@@ -3,11 +3,13 @@ kind: Service
 metadata:
   name: redis
   namespace: cash-track
+  annotations:
+    tailscale.com/expose: 'true'
+    tailscale.com/hostname: ct-prod-redis
 spec:
-  clusterIP: None
   selector:
     app: redis
   ports:
     - port: 6379
-      targetPort: 6379
       name: redis
+      targetPort: redis


### PR DESCRIPTION
- Added Tailscale as internal network provider for internal purposes.
- Removed Kubernetes Dashboard due to lack of authentication configuration
