### PR TITLE
Fix Grafana config, update client error alert

### DIFF
--- a/services/grafana/configs/grafana.ini
+++ b/services/grafana/configs/grafana.ini
@@ -5,7 +5,7 @@ enforce_domain = true
 enable_gzip = true
 
 [security]
-cookie_secure = true
+cookie_secure = false
 cookie_samesite = strict
 
 [log]

--- a/services/prometheus/configs/rules.yml
+++ b/services/prometheus/configs/rules.yml
@@ -111,7 +111,7 @@ groups:
           description: "Service {{ $labels.service }} responding to {{ $labels.method }} {{ $labels.path }} with HTTP status code {{ $labels.status }} for more than {{ $value }}% requests for last 5 minutes"
 
       - alert: HTTPServiceHighClientErrorRate
-        expr: round((sum by (service, method, path, status) (rate(nginx_ingress_controller_requests{service=~"api|website|frontend|crashers-bot",status=~"4.."}[2m])) / sum by (service, method, path, status) (rate(nginx_ingress_controller_requests{service=~"api|website|frontend|crashers-bot"}[2m]))) * 100) > 80
+        expr: round((sum by (service, method, path, status) (rate(nginx_ingress_controller_requests{service=~"api|website|frontend|crashers-bot",status=~"4..",status!="404"}[2m])) / sum by (service, method, path, status) (rate(nginx_ingress_controller_requests{service=~"api|website|frontend|crashers-bot"}[2m]))) * 100) > 80
         for: 5m
         labels:
           severity: info


### PR DESCRIPTION
Added some fixes after Grafana upgrade. Update client error alert to ignore 404 client errors.