### PR TITLE
feat(infra): migrate Tailscale auth from API key to OAuth client

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -49,7 +49,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.SPACES_TFSTATE_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SPACES_TFSTATE_KEY }}
           DIGITALOCEAN_TOKEN: op://cash-track-prod/do-api/TOKEN
-          TF_VAR_tailscale_api_key: op://cash-track-prod/tailscale/API_KEY
+          TF_VAR_tailscale_oauth_client_id: op://cash-track-prod/tailscale/OAUTH_CLIENT_ID
+          TF_VAR_tailscale_oauth_client_secret: op://cash-track-prod/tailscale/OAUTH_CLIENT_SECRET
         run: |
           set -eo pipefail
           op run -- terraform apply -auto-approve -json | jq -r '

--- a/migration/2026-04-21-kubernetes-to-docker-compose-design.md
+++ b/migration/2026-04-21-kubernetes-to-docker-compose-design.md
@@ -203,7 +203,7 @@ volume_tag            = "cashtrack-data"
 
 domain                = "cash-track.app"
 ssh_key_fingerprints  = ["aa:bb:cc:..."]    # fallback; primary path is Tailscale SSH
-tailscale_tags        = ["tag:prod-server"]
+tailscale_tags        = ["tag:cashtrack-prod"]
 cf_ipv4_url           = "https://www.cloudflare.com/ips-v4"
 cf_ipv6_url           = "https://www.cloudflare.com/ips-v6"
 
@@ -337,7 +337,7 @@ runcmd:
   - curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.noarmor.gpg | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
   - curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.tailscale-keyring.list | tee /etc/apt/sources.list.d/tailscale.list
   - apt-get update && apt-get install -y tailscale
-  - tailscale up --authkey=${tailscale_authkey} --hostname=${hostname} --advertise-tags=tag:prod-server --ssh --accept-routes
+  - tailscale up --authkey=${tailscale_authkey} --hostname=${hostname} --advertise-tags=tag:cashtrack-prod --ssh --accept-routes
 
   # Docker
   - install -m 0755 -d /etc/apt/keyrings
@@ -1200,7 +1200,7 @@ jobs:
             "/opt/cashtrack/bin/deploy-service ${SERVICE} ${TAG} ${RUN_MIGRATIONS}"
 ```
 
-No infra checkout. No Ansible on the runner. No vault access. No PAT. SSH auth is Tailscale SSH, keyless — governed by the tailnet ACL granting `tag:ci` identity SSH to `tag:prod-server` as user `ops`.
+No infra checkout. No Ansible on the runner. No vault access. No PAT. SSH auth is Tailscale SSH, keyless — governed by the tailnet ACL granting `tag:ci` identity SSH to `tag:cashtrack-prod` as user `ops`.
 
 ### Caller in a service repo (`cash-track/api/.github/workflows/release.yml`)
 
@@ -1411,8 +1411,8 @@ Implemented as two Ansible playbooks using the `community.digitalocean` collecti
 
 ### Tailscale ACLs (conceptual; configured in Tailscale admin)
 
-- `tag:prod-server` — the droplet
-- `tag:ci` — ephemeral GitHub Actions runners; can SSH to `tag:prod-server` as `ops`
+- `tag:cashtrack-prod` — the droplet
+- `tag:ci` — ephemeral GitHub Actions runners; can SSH to `tag:cashtrack-prod` as `ops`
 - `group:admin` — operators; can SSH + access Grafana / Prometheus / Alertmanager
 
 Grafana and other internal dashboards are exposed through `tailscale serve` on the droplet, reachable only on the tailnet.

--- a/migration/2026-04-23-implementation-plan.md
+++ b/migration/2026-04-23-implementation-plan.md
@@ -1033,12 +1033,12 @@ Tell operator: *"Stage 10 committed. Before `make deploy`: confirm the `home-exp
 2. **[OPERATOR-ONLY] Edit Tailscale ACLs** — add:
    ```json
    {
-     "tagOwners": { "tag:ci": ["autogroup:admin"], "tag:prod-server": ["autogroup:admin"] },
+     "tagOwners": { "tag:ci": ["autogroup:admin"], "tag:cashtrack-prod": ["autogroup:admin"] },
      "acls": [
-       { "action": "accept", "src": ["tag:ci"], "dst": ["tag:prod-server:22"] }
+       { "action": "accept", "src": ["tag:ci"], "dst": ["tag:cashtrack-prod:22"] }
      ],
      "ssh": [
-       { "action": "accept", "src": ["tag:ci"], "dst": ["tag:prod-server"], "users": ["ops"] }
+       { "action": "accept", "src": ["tag:ci"], "dst": ["tag:cashtrack-prod"], "users": ["ops"] }
      ]
    }
    ```

--- a/terraform/modules/droplet/templates/cloud-init.yaml
+++ b/terraform/modules/droplet/templates/cloud-init.yaml
@@ -33,7 +33,7 @@ runcmd:
   - curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.noarmor.gpg | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
   - curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.tailscale-keyring.list | tee /etc/apt/sources.list.d/tailscale.list
   - apt-get update && apt-get install -y tailscale
-  - tailscale up --authkey=${tailscale_authkey} --hostname=${hostname} --advertise-tags=tag:prod-server --ssh --accept-routes
+  - tailscale up --authkey="${tailscale_authkey}?ephemeral=false&preauthorized=true" --hostname=${hostname} --advertise-tags=tag:cashtrack-prod --ssh --accept-routes
 
   # Docker
   - install -m 0755 -d /etc/apt/keyrings

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -3,5 +3,6 @@ provider "digitalocean" {
 }
 
 provider "tailscale" {
-  api_key = var.tailscale_api_key
+  oauth_client_id     = var.tailscale_oauth_client_id
+  oauth_client_secret = var.tailscale_oauth_client_secret
 }

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -18,7 +18,7 @@ ssh_key_fingerprints = ["2f:b7:25:a6:04:b1:fe:9e:b3:99:a5:af:00:4b:7f:8d"]
 # (e.g. the contents of ~/.ssh/cashtrack_ops.pub).
 ops_ssh_public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIcRk11JzJTAza6IN1/L62XY6mpKKrdqu/ZdgRWlWre5 vovikems@gmail.com"
 
-tailscale_tags = ["tag:prod-server"]
+tailscale_tags = ["tag:cashtrack-prod"]
 
 cf_ipv4_url = "https://www.cloudflare.com/ips-v4"
 cf_ipv6_url = "https://www.cloudflare.com/ips-v6"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,8 +58,14 @@ variable "tailscale_tags" {
   type        = list(string)
 }
 
-variable "tailscale_api_key" {
-  description = "Tailscale personal API key. Provided via TF_VAR_tailscale_api_key."
+variable "tailscale_oauth_client_id" {
+  description = "Tailscale OAuth client ID used to authenticate the tailscale provider."
+  type        = string
+  sensitive   = true
+}
+
+variable "tailscale_oauth_client_secret" {
+  description = "Tailscale OAuth client secret used to authenticate the tailscale provider."
   type        = string
   sensitive   = true
 }


### PR DESCRIPTION
## Summary

- Replace Tailscale personal API key (90-day expiry) with an OAuth client credential that never expires
- Update Terraform provider to authenticate via `oauth_client_id` + `oauth_client_secret`; remove `tailscale_api_key` variable
- Update `bootstrap.yml` to inject `TF_VAR_tailscale_oauth_client_id` / `TF_VAR_tailscale_oauth_client_secret` from 1Password (`op://cash-track-prod/tailscale/OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET`)

The shared `.github` workflows (`ansible.yml`, `deploy.yml`) were updated in the `cash-track/.github` repo and pushed to `main` separately:
- `ansible.yml`: `TS_AUTH_KEY` → `TS_OAUTH_CLIENT_ID` + `TS_OAUTH_SECRET`; Tailscale node tagged `tag:cashtrack-infra`
- `deploy.yml`: same secret swap; Tailscale node tagged `tag:ci`

## Operator actions required before merging

1. Add GitHub secrets `TS_OAUTH_CLIENT_ID` and `TS_OAUTH_SECRET` to the `prod` environment (values from `op://cash-track-prod/tailscale/OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET`)
2. Verify a deployment or dry-run Ansible run succeeds with the new secrets
3. Remove the old `TS_AUTH_KEY` secret