### PR TITLE
fix(infra): reload Prometheus after config-tree upload

### DIFF
--- a/ansible/roles/compose-up/handlers/main.yml
+++ b/ansible/roles/compose-up/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+# Prometheus exposes POST /-/reload when started with --web.enable-lifecycle.
+# Sending a reload after any config-tree upload avoids a full container restart
+# and picks up new rule files and scrape jobs immediately.
+- name: Reload Prometheus
+  ansible.builtin.command:
+    cmd: docker exec cashtrack-prometheus-1 wget -qO- --post-data='' http://localhost:9090/-/reload
+  changed_when: true

--- a/ansible/roles/compose-up/tasks/main.yml
+++ b/ansible/roles/compose-up/tasks/main.yml
@@ -39,6 +39,7 @@
   delegate_to: localhost
   become: false
   changed_when: true
+  notify: Reload Prometheus
 
 - name: Fix config tree ownership
   ansible.builtin.file:


### PR DESCRIPTION
## Summary

After a deploy the Ansible `compose-up` role runs `docker compose up --no-recreate` (`state: present`), which never recreates a running container. Config files land on disk via rsync but Prometheus keeps serving the old config until it restarts.

Prometheus is started with `--web.enable-lifecycle`, which exposes `POST /-/reload`. This PR adds a `Reload Prometheus` handler to the `compose-up` role that fires after every config-tree rsync, sending a reload signal so new rule files and scrape jobs are picked up immediately without a container restart.