### PR TITLE
feat(infra): inject VITE_* runtime config into frontend env

### DIFF
--- a/ansible/roles/compose-render/templates/frontend.env.tpl
+++ b/ansible/roles/compose-render/templates/frontend.env.tpl
@@ -1,9 +1,19 @@
-{# Mirrors infra/services/frontend/deployment.yml. The frontend image's
-   entrypoint substitutes these into the served bundle / nginx config at
-   container start (Vue 2 build still consumes VUE_APP_*; the Vue 3 + Vite
-   migration tracked in /frontend/MIGRATION.md will eventually swap to VITE_*).
+{# Rendered into secrets/frontend.env and consumed by the frontend image's
+   entrypoint at container start.
+
+   The current Vue 3 + Vite app reads VITE_WEBSITE_URL / VITE_GATEWAY_URL — the
+   entrypoint injects them into window.__APP_CONFIG__ in the served index.html and
+   fails fast if either is unset (see /frontend/entrypoint.sh). Without them the SPA
+   resolves config to `undefined` and redirect-loops to /undefined/undefined/….
+
+   The legacy Vue 2 VUE_APP_* vars are retained for backward compatibility so an
+   older frontend image can be rolled back without re-rendering this file; the Vite
+   entrypoint ignores them. Remove them once rollback is no longer a concern.
+
    No op:// references — pure URL config — but rendered through the same
    compose-render flow as the rest for uniformity. #}
+VITE_WEBSITE_URL=https://cash-track.app
+VITE_GATEWAY_URL=https://gateway.cash-track.app
 VUE_APP_BASE_URL=https://my.cash-track.app
 VUE_APP_API_URL=https://api.cash-track.app
 VUE_APP_WEBSITE_URL=https://cash-track.app

--- a/compose/compose.app.yml
+++ b/compose/compose.app.yml
@@ -54,8 +54,9 @@ services:
     image: cashtrack/frontend:${VERSION_FRONTEND}
     restart: always
     networks: [app]
-    # The image's entrypoint substitutes VUE_APP_* into the served bundle /
-    # nginx config at start (matches infra/services/frontend/deployment.yml).
+    # The image's entrypoint injects VITE_WEBSITE_URL / VITE_GATEWAY_URL into
+    # window.__APP_CONFIG__ in the served index.html at start (and fails fast if
+    # either is unset). Legacy VUE_APP_* are kept in the env file for rollback only.
     env_file: [secrets/frontend.env]
     labels:
       - traefik.enable=true


### PR DESCRIPTION
## Why

The Vue 3 + Vite frontend reads `VITE_WEBSITE_URL` / `VITE_GATEWAY_URL` at container start — `entrypoint.sh` injects them into `window.__APP_CONFIG__` in the served `index.html` and **fails fast** if either is unset. The env template only emitted the legacy Vue 2 `VUE_APP_*` vars, which the new app ignores, so production resolved config to `undefined` and the SPA redirect-looped to `/undefined/undefined/…`.

## What

- `frontend.env.tpl`: add `VITE_WEBSITE_URL` and `VITE_GATEWAY_URL`; keep the four `VUE_APP_*` for backward compatibility so an older frontend image can be rolled back without re-rendering the file.
- `compose.app.yml`: update the stale frontend comment (the referenced K8s `services/frontend/deployment.yml` no longer exists).

## Rollout ordering

This change is backward-compatible — the current image ignores `VITE_*` and still reads `VUE_APP_*`, so merging it alone is a no-op at runtime. The fix takes effect only once the **new frontend image** (with the runtime-injection entrypoint) is deployed.

Because the new entrypoint fails fast without `VITE_*`, land this env change **before or with** the new image:
1. Merge this PR → ansible run renders `secrets/frontend.env` with `VITE_*`.
2. Then release/deploy the new frontend image.