### PR TITLE
feat(infra): wire TRACE_CAPTURE_BODY env var for gateway

### DIFF
--- a/ansible/roles/compose-render/templates/gateway.env.tpl
+++ b/ansible/roles/compose-render/templates/gateway.env.tpl
@@ -4,6 +4,7 @@
 GATEWAY_ADDRESS=:8081
 GATEWAY_COMPRESS=true
 DEBUG_HTTP=false
+TRACE_CAPTURE_BODY=true
 HTTPS_ENABLED=false
 CORS_ALLOWED_ORIGINS=https://cash-track.app,https://my.cash-track.app
 REDIS_CONNECTION=redis:6379


### PR DESCRIPTION
## Summary
- Gateway PR cash-track/gateway#39 adds a `TRACE_CAPTURE_BODY` config flag (kill switch for redacted request/response body capture on trace spans, defaults `true`).
- `gateway.env.tpl` (rendered into `secrets/gateway.env` for the Compose deployment) didn't set this var, so infra was silently relying on the binary's default instead of declaring it explicitly like the other gateway flags (`DEBUG_HTTP`, `GATEWAY_COMPRESS`, etc).