### PR TITLE
docs(infra): document Cloudflare cache rules required for sw.js

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -550,6 +550,30 @@ Grafana and internal dashboards are exposed via `tailscale serve`, reachable onl
 
 Traefik's `cloudflare-only` IP allowlist middleware is applied to all external routers. If the DO Firewall's CF IP list ever lags behind a CF range update, Traefik still rejects non-CF source IPs.
 
+### Cloudflare zone cache configuration
+
+Cloudflare's default "Cache Everything by extension" behavior edge-caches static file types including `.js`, and the zone's Browser Cache TTL setting can override the origin's `Cache-Control` header — rewriting the frontend's `no-cache, no-store, must-revalidate` on `sw.js` to a fixed `max-age` (observed: `14400`, i.e. 4h). Left unmitigated, this delays service worker update discovery — and therefore SPA deploy propagation to already-open tabs — by up to 4 hours after every release (cash-track/frontend#106).
+
+**Required zone settings (`my.cash-track.app`):**
+
+- **Cache Rule — Bypass cache** for `my.cash-track.app/sw.js`. Required so the service worker script is never edge- or browser-cached, independent of the Browser Cache TTL setting below.
+- **Browser Cache TTL — Respect Existing Headers.** Stops Cloudflare from overriding origin-set `Cache-Control` on any other response.
+
+**Verification:**
+
+```bash
+curl -sI https://my.cash-track.app/sw.js
+```
+
+Expect both:
+
+```
+cache-control: no-cache, no-store, must-revalidate
+cf-cache-status: BYPASS
+```
+
+If `cf-cache-status` comes back `HIT`/`DYNAMIC`/`EXPIRED` instead of `BYPASS`, or `cache-control` shows a `max-age`, the Cache Rule is missing or misconfigured — fix it in the Cloudflare dashboard (Caching → Cache Rules) before chasing stale-SW reports downstream.
+
 ---
 
 ## 14. Observability


### PR DESCRIPTION
## Problem statement

Related to cash-track/frontend#106. The frontend origin serves `/sw.js` with `Cache-Control: no-cache, no-store, must-revalidate`, but production responses come back `cache-control: max-age=14400, must-revalidate` with `cf-cache-status: HIT` — Cloudflare's default extension-based caching edge-caches the `.js` file and a zone Browser Cache TTL setting rewrites the header. Browsers bypass their own HTTP cache when checking for service-worker updates, but they cannot bypass Cloudflare's edge copy, so every deploy is invisible to service-worker clients for up to 4 hours. The Cloudflare zone is configured manually (not managed by Terraform) and this requirement was undocumented.

## Changes

Adds an operator runbook subsection to `docs/design.md` (under Network Security): the required Cache Rule (**Bypass cache** for `my.cash-track.app/sw.js`), the Browser Cache TTL recommendation (**Respect Existing Headers**), the rationale, and a `curl` verification command with the expected `cache-control` and `cf-cache-status: BYPASS` output.

## Verification

Docs-only change. Header behaviour verified against production (`curl -sI https://my.cash-track.app/sw.js` showing the rewritten header + edge HIT) and against the frontend image run locally (origin emits `no-store`, confirming the rewrite happens at the edge).