### PR TITLE
fix(infra): run post-deploy commands with no trailing newline

### DIFF
--- a/ansible/roles/compose-up/files/deploy-service
+++ b/ansible/roles/compose-up/files/deploy-service
@@ -46,7 +46,10 @@ if [[ -n "$POST_CMDS_B64" ]]; then
   # Each command is validated: only alphanumerics, spaces, and safe punctuation
   # (.  /  :  -  _) are allowed — shell operators are rejected.
   safe_cmd_re='^[A-Za-z0-9 ./:_-]{1,200}$'
-  while IFS= read -r cmd; do
+  # `|| [[ -n "$cmd" ]]` also runs the loop body for a final line with no
+  # trailing newline — without it, `read` fails on EOF before the newline-less
+  # single-command case (e.g. one migrate command) ever reaches the body.
+  while IFS= read -r cmd || [[ -n "$cmd" ]]; do
     [[ -z "$cmd" ]] && continue
     if [[ ! "$cmd" =~ $safe_cmd_re ]]; then
       echo "deploy-service: refusing unsafe command: $cmd" >&2; exit 2


### PR DESCRIPTION
## Summary
- \`deploy-service\`'s post-deploy-commands loop (\`while read cmd; do ... done < <(base64 -d ...)\`) silently skipped its body whenever the decoded payload had no trailing newline — the normal case for a single command like the api migration.
- \`read\` hits EOF before a newline and returns non-zero; since that only drives the \`while\` condition, \`set -e\` doesn't treat it as fatal, so the loop exits with nothing run and the script falls straight through to \`up -d\`. No error, no output — that's why the last two api deploys pulled/restarted fine but never ran the migration.
- Fix: \`while IFS= read -r cmd || [[ -n "$cmd" ]]; do\` also processes an unterminated final line.
- Reproduced live with \`bash -x\` against a copy of the script and a harmless \`php -v\` payload; confirmed the fix by applying it directly to the running \`/opt/cashtrack/bin/deploy-service\` (so the current droplet already has it, independent of this PR merging/deploying).

Companion fix in \`cash-track/.github\` (defense in depth): cash-track/.github#2