### PR TITLE
feat(infra): provision the gateway/api shared secret and trusted proxies

### DIFF
--- a/ansible/roles/compose-render/templates/api.env.tpl
+++ b/ansible/roles/compose-render/templates/api.env.tpl
@@ -60,6 +60,7 @@ DB_ENCRYPTER_KEY={{ op_prefix }}/api/DB_ENCRYPTER_KEY
 # common vault — shared with gateway / website / mysql-backup
 CAPTCHA_CLIENT_KEY={{ op_prefix }}/common/CAPTCHA_CLIENT_KEY
 CAPTCHA_SECRET_KEY={{ op_prefix }}/common/CAPTCHA_SECRET_KEY
+GATEWAY_SECRET={{ op_prefix }}/common/GATEWAY_SECRET
 GOOGLE_API_CLIENT_ID={{ op_prefix }}/common/GOOGLE_API_CLIENT_ID
 GOOGLE_API_CLIENT_SECRET={{ op_prefix }}/common/GOOGLE_API_CLIENT_SECRET
 GOOGLE_API_PROJECT_ID={{ op_prefix }}/common/GOOGLE_API_PROJECT_ID

--- a/ansible/roles/compose-render/templates/gateway.env.tpl
+++ b/ansible/roles/compose-render/templates/gateway.env.tpl
@@ -10,6 +10,9 @@ CORS_ALLOWED_ORIGINS=https://cash-track.app,https://my.cash-track.app
 REDIS_CONNECTION=redis:6379
 CSRF_ENABLED=true
 
+# Traefik and gateway share the same Compose bridge network.
+TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.0/8,::1/128
+
 # Cross-service URLs (matches K8s common-config bindings)
 GATEWAY_URL=https://gateway.cash-track.app
 API_URL=http://api:8080
@@ -23,5 +26,6 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317
 OTEL_EXPORTER_OTLP_INSECURE=true
 OTEL_SERVICE_INSTANCE_ID=gateway
 
-# common vault — only the captcha secret. Same field used by api / website.
+# common vault — GATEWAY_SECRET must match the api's.
 CAPTCHA_SECRET={{ op_prefix }}/common/CAPTCHA_SECRET_KEY
+GATEWAY_SECRET={{ op_prefix }}/common/GATEWAY_SECRET


### PR DESCRIPTION
## Problem statement

The gateway/API trust-boundary fix needs a shared secret present in both services' environments, and the gateway's `TRUSTED_PROXIES` value needs to reflect the Compose topology rather than the K8s one it was written for.

Companion PRs: `cash-track/gateway` (sends the header) and `cash-track/api` (verifies it). This PR only provisions the values.

## Changes

- `api.env.tpl` — adds `GATEWAY_SECRET={{ op_prefix }}/common/GATEWAY_SECRET`.
- `gateway.env.tpl` — adds the same reference, and documents that `TRUSTED_PROXIES` covers the private ranges because Traefik and the gateway share the Compose bridge network.

Both read the same `op://cash-track-prod/common/GATEWAY_SECRET` field, which is what makes the two sides match.

## Verification

- `ansible-playbook --syntax-check` and `ansible-lint` clean. No production actions were run.
- Template rendering verified offline; the `op://` references follow the existing `op_prefix` pattern used by the neighbouring `CAPTCHA_SECRET` line.

## Two deployment hazards, both real

**1. The 1Password field is a hard prerequisite.** `op inject` runs on the control node and aborts the play if `op://cash-track-prod/common/GATEWAY_SECRET` does not exist. It fails before the ship task, so there is no partial state — but the play will not complete until the field is created.

**2. Ansible runs handlers in definition order, not notification order.** `Restart api` is defined before `Restart gateway`. Because this commit adds the secret to both templates at once, a single deploy transits one broken state: the API has the secret while the gateway is not yet sending it, so all gateway traffic is treated as untrusted, its IP headers are rewritten to the gateway container's address, and every user collapses into one `guest:<gateway-ip>` bucket at 100 req/60s.

The two-pass rollout in `api/docs/deployment/2026-08-07-gateway-trust-boundary.md` eliminates that window — it is safe because *gateway-set / api-unset* is a pure no-op. The single-deploy window is short but real; pick deliberately rather than by default.
