### PR TITLE
chore(infra): drop CORS_ALLOWED_ORIGINS from the API env template

### DIFF
--- a/ansible/roles/compose-render/templates/api.env.tpl
+++ b/ansible/roles/compose-render/templates/api.env.tpl
@@ -25,7 +25,6 @@ CDN_BUCKET=cash-track-storage
 MAIL_DRIVER=smtp
 MAIL_SENDER_NAME=Cash Track
 MAIL_SENDER_ADDRESS=support@mail.cash-track.app
-CORS_ALLOWED_ORIGINS=https://cash-track.app,https://my.cash-track.app
 RR_HTTP_NUM_WORKERS=6
 AUTH_PASSKEY_SERVICE_ID=cash-track.app
 AUTH_PASSKEY_SERVICE_NAME=Cash Track


### PR DESCRIPTION
## Problem statement

The API no longer handles CORS — the gateway owns it exclusively now (cash-track/api#220, cash-track/gateway#57). The API's Compose env template still had a `CORS_ALLOWED_ORIGINS` line the API no longer reads.

## Changes

- Removed `CORS_ALLOWED_ORIGINS` from `ansible/roles/compose-render/templates/api.env.tpl`.
- Gateway's own `gateway.env.tpl` keeps its `CORS_ALLOWED_ORIGINS` unchanged — it still needs it.

## Verification

- `git diff --stat` — 1 file, 1 line removed, no other changes.
