### PR TITLE
feat(compose,ansible): wire recipes-bot into the telegram compose stack

### DIFF
--- a/ansible/group_vars/all/main.yml
+++ b/ansible/group_vars/all/main.yml
@@ -17,6 +17,9 @@ versions:
   # the org `ship-service.yml` workflow.
   crashers_bot: "1.3.3"
   home_exporter: "0.0.4"
+  # vovanms/recipes_bot image, same outside-the-org pattern as crashers_bot /
+  # home_exporter above — pulled from Docker Hub, bumped by hand.
+  recipes_bot: "0.1.0"
   # vovanms/wordpress-backup image, used by the potwora-backup service.
   # Built from potwora/deploy/Dockerfile.backup and pushed manually
   # (same pattern as crashers_bot / home_exporter).
@@ -55,6 +58,7 @@ secret_files:
   - grafana
   - crashers-bot
   - home-exporter
+  - recipes-bot
   - potwora
   - potwora-backup
 

--- a/ansible/roles/compose-render/defaults/main.yml
+++ b/ansible/roles/compose-render/defaults/main.yml
@@ -27,6 +27,7 @@ secret_files:
   - grafana
   - crashers-bot
   - home-exporter
+  - recipes-bot
   - potwora
   - potwora-backup
 

--- a/ansible/roles/compose-render/templates/env.tpl
+++ b/ansible/roles/compose-render/templates/env.tpl
@@ -11,4 +11,5 @@ VERSION_MYSQL_BACKUP={{ versions.mysql_backup }}
 VERSION_REDIS={{ versions.redis }}
 VERSION_CRASHERS_BOT={{ versions.crashers_bot }}
 VERSION_HOME_EXPORTER={{ versions.home_exporter }}
+VERSION_RECIPES_BOT={{ versions.recipes_bot }}
 VERSION_POTWORA_BACKUP={{ versions.potwora_backup }}

--- a/ansible/roles/compose-render/templates/recipes-bot.env.tpl
+++ b/ansible/roles/compose-render/templates/recipes-bot.env.tpl
@@ -1,0 +1,35 @@
+{# Rendered by ansible/roles/compose-render into
+   /opt/cashtrack/secrets/recipes-bot.env (0600, ops:ops). Non-secret values
+   are literals; secrets are op:// references resolved by `op inject`. #}
+APP_ENV=production
+LOG_LEVEL=info
+HTTP_ADDR=:8080
+TEMP_DIR=/tmp/recipes
+
+TELEGRAM_WEBHOOK_BASE_URL=https://recipes-bot.cash-track.app
+TELEGRAM_DROP_PENDING_UPDATES=true
+
+OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_MODEL=gpt-5.2
+TRANSCRIBE_BASE_URL=https://api.openai.com/v1
+TRANSCRIBE_MODEL=gpt-4o-transcribe
+
+NOTION_DATABASE_TITLE=Рецепти
+NOTION_VERSION=2026-03-11
+
+WORKER_CONCURRENCY=1
+WORKER_QUEUE_SIZE=8
+WORKER_JOB_TIMEOUT=10m
+
+# recipes-bot vault item
+TELEGRAM_BOT_TOKEN={{ op_prefix }}/recipes-bot/TELEGRAM_BOT_TOKEN
+TELEGRAM_BOT_USERNAME={{ op_prefix }}/recipes-bot/TELEGRAM_BOT_USERNAME
+TELEGRAM_WEBHOOK_PATH_SECRET={{ op_prefix }}/recipes-bot/TELEGRAM_WEBHOOK_PATH_SECRET
+TELEGRAM_WEBHOOK_SECRET_TOKEN={{ op_prefix }}/recipes-bot/TELEGRAM_WEBHOOK_SECRET_TOKEN
+TELEGRAM_ALLOWED_CHAT_IDS={{ op_prefix }}/recipes-bot/TELEGRAM_ALLOWED_CHAT_IDS
+TELEGRAM_ADMIN_CHAT_ID={{ op_prefix }}/recipes-bot/TELEGRAM_ADMIN_CHAT_ID
+OPENAI_API_KEY={{ op_prefix }}/recipes-bot/OPENAI_API_KEY
+TRANSCRIBE_API_KEY={{ op_prefix }}/recipes-bot/TRANSCRIBE_API_KEY
+NOTION_API_KEY={{ op_prefix }}/recipes-bot/NOTION_API_KEY
+NOTION_ROOT_PAGE_ID={{ op_prefix }}/recipes-bot/NOTION_ROOT_PAGE_ID
+NOTION_DATA_SOURCE_ID={{ op_prefix }}/recipes-bot/NOTION_DATA_SOURCE_ID

--- a/ansible/roles/volume/tasks/main.yml
+++ b/ansible/roles/volume/tasks/main.yml
@@ -47,3 +47,17 @@
   loop: "{{ volume_subdir_owners | dict2items }}"
   loop_control:
     label: "{{ item.key }} (uid={{ item.value }})"
+
+# recipes-bot's yt-dlp/ffmpeg scratch mount. Kept out of volume_subdir_owners
+# because it needs 0750 (not the generic 0755) — scratch holds
+# attacker-influenced downloaded bytes and has no reason to be world-readable
+# — and uid 10001 is the image's `app` user, not a per-service convention
+# shared with the rest of that dict. Docker would otherwise create this
+# root-owned on first `up`, and the bot fails its writability check at boot.
+- name: Create recipes-bot scratch subdirectory
+  ansible.builtin.file:
+    path: /mnt/data/recipes-bot/scratch
+    state: directory
+    owner: "10001"
+    group: "10001"
+    mode: "0750"

--- a/compose/compose.telegram.yml
+++ b/compose/compose.telegram.yml
@@ -1,12 +1,13 @@
 # Telegram-namespace apps. crashers-bot is a Laravel HTTP bot (Telegram webhook
 # receiver + scheduler); home-exporter is a Prometheus-style exporter that
-# ICMP-pings remote hosts and reports state to Telegram. Both source repos live
+# ICMP-pings remote hosts and reports state to Telegram; recipes-bot turns
+# social-media recipe links into Notion pages. All three source repos live
 # outside the cash-track GitHub org, so their images are pulled from the upstream
 # `vovanms/*` Docker Hub namespace (public, no imagePullSecrets — matches the
-# K8s deployments). The cash-track org-level release workflow (Stage 11/12) does
-# NOT manage these images; the operator bumps `versions.crashers_bot` /
-# `versions.home_exporter` in `group_vars/all/main.yml` when a new upstream tag
-# ships.
+# K8s deployments where applicable). The cash-track org-level release workflow
+# (Stage 11/12) does NOT manage these images; the operator bumps
+# `versions.crashers_bot` / `versions.home_exporter` / `versions.recipes_bot`
+# in `group_vars/all/main.yml` when a new upstream tag ships.
 
 networks:
   app:
@@ -91,3 +92,38 @@ services:
     mem_limit: 128m
     mem_reservation: 96m
     oom_score_adj: 0
+
+  recipes-bot:
+    image: vovanms/recipes_bot:${VERSION_RECIPES_BOT}
+    restart: always
+    networks: [app]
+    env_file: [secrets/recipes-bot.env]
+    volumes:
+      # Scratch for yt-dlp/ffmpeg. Disk-backed on purpose, NOT tmpfs: tmpfs
+      # pages are charged to this container's memory cgroup, so a 200 MB video
+      # in scratch would count against mem_limit twice over and OOM-kill the
+      # process mid-job. /mnt/data is the block volume, directory owned by
+      # uid/gid 10001 via ansible/roles/volume (see docs/DEPLOYMENT.md §3).
+      - /mnt/data/recipes-bot/scratch:/tmp/recipes:rw,noexec,nosuid
+      # Instagram cookie jar — not wired up yet. Add
+      # `./secrets/recipes-bot/cookies.txt:/app/cookies.txt:ro` here, plus the
+      # matching secret_config_files entry in group_vars/all/main.yml and
+      # compose-render/defaults/main.yml, and YTDLP_COOKIES_FILE in the env
+      # template, once cookies are actually provisioned in 1Password
+      # (docs/DEPLOYMENT.md §3 step 1, runbook §6 "Downloads failing").
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/recipes-bot", "-healthcheck"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.recipes-bot.rule=Host(`recipes-bot.${DOMAIN}`)
+      - traefik.http.routers.recipes-bot.entrypoints=websecure
+      - traefik.http.routers.recipes-bot.tls=true
+      - traefik.http.services.recipes-bot.loadbalancer.server.port=8080
+      - traefik.http.routers.recipes-bot.middlewares=cloudflare-only@file
+    mem_limit: 512m
+    mem_reservation: 192m
+    oom_score_adj: -100


### PR DESCRIPTION
## Problem statement

recipes-bot (vovanms/recipes-automation) is ready to deploy alongside
crashers-bot and home-exporter but isn't wired into this repo yet.
`docs/DEPLOYMENT.md` §3 in that repo specifies the exact infra changes
needed.

## Changes

- `ansible/group_vars/all/main.yml`: `versions.recipes_bot` pin and a
  `recipes-bot` entry in `secret_files`.
- `ansible/roles/compose-render/defaults/main.yml`: mirrors the
  `secret_files` addition for isolated role dry-runs.
- `ansible/roles/compose-render/templates/env.tpl`:
  `VERSION_RECIPES_BOT`.
- `ansible/roles/compose-render/templates/recipes-bot.env.tpl` (new):
  non-secret literals plus `op://` references for the recipes-bot vault
  item, rendered to `/opt/cashtrack/secrets/recipes-bot.env`.
- `ansible/roles/volume/tasks/main.yml`: a dedicated task creating
  `/mnt/data/recipes-bot/scratch` (mode 0750, uid/gid 10001 — the
  image's `app` user) so the disk-backed scratch mount exists with the
  right owner before first start.
- `compose/compose.telegram.yml`: the `recipes-bot` service — scratch
  volume, healthcheck via the binary's `-healthcheck` flag, Traefik
  labels for `recipes-bot.${DOMAIN}`, and mem limits sized for one
  concurrent job (512m limit / 192m reservation).

Left out on purpose: the Instagram cookie jar bind mount is commented,
not active — it isn't provisioned in 1Password yet, and mounting a
nonexistent file would break the first `docker compose up`. Also out
of scope for this PR: the Cloudflare DNS record, `make deploy`, and
seeding `VERSION_RECIPES_BOT` on the live `.env` — those are
operational steps for actual first deploy, not infra-repo code.

## Verification

- `ansible-playbook --syntax-check site.yml` passes.
- `ansible-lint` on the three changed Ansible files: 0 failures, 0
  warnings.
- `docker compose -f compose.core.yml -f compose.telegram.yml config`
  renders cleanly with stub env files; the rendered `recipes-bot`
  service block (image tag, healthcheck, Traefik labels, mem limits)
  matches the spec in `docs/DEPLOYMENT.md` §2.