### PR TITLE
fix(ansible): add missing Restart recipes-bot handler

### DIFF
--- a/ansible/roles/compose-render/handlers/main.yml
+++ b/ansible/roles/compose-render/handlers/main.yml
@@ -89,6 +89,13 @@
     services: [home-exporter]
     state: restarted
 
+- name: Restart recipes-bot
+  community.docker.docker_compose_v2:
+    project_src: "{{ droplet_project_dir }}"
+    files: "{{ compose_files }}"
+    services: [recipes-bot]
+    state: restarted
+
 - name: Restart potwora
   community.docker.docker_compose_v2:
     project_src: "{{ droplet_project_dir }}"


### PR DESCRIPTION
## Problem

#78 added `recipes-bot` to `secret_files` but not the matching `Restart recipes-bot` handler. The `apply` job now fails on every run that touches env templates:

```
[ERROR]: The requested handler 'Restart recipes-bot' was not found in either the main handlers list nor in the listening handlers list
```

Run: https://github.com/cash-track/infra/actions/runs/32410583145/job/96563153096

## Changes

Add `Restart recipes-bot` to `ansible/roles/compose-render/handlers/main.yml`, same pattern as every other `secret_files` entry.

## Verification

- `ansible-lint ansible/roles/compose-render/handlers/main.yml` — 0 failures, 0 warnings
- `ansible-playbook --syntax-check site.yml` — passes