### PR TITLE
fix(compose-up): add recipes-bot to deploy-service's allowlist

### DIFF
--- a/ansible/roles/compose-up/files/deploy-service
+++ b/ansible/roles/compose-up/files/deploy-service
@@ -16,7 +16,7 @@ POST_CMDS_B64="${3:-}"
 # Allowlist: any change here requires a privileged operator to update the
 # script on the droplet. Keep in sync with compose service names.
 case "$SERVICE" in
-  api|gateway|website|frontend|mysql|mysql-backup|mysql-backup-crashers|redis|crashers-bot|home-exporter) ;;
+  api|gateway|website|frontend|mysql|mysql-backup|mysql-backup-crashers|redis|crashers-bot|home-exporter|recipes-bot) ;;
   *) echo "deploy-service: refusing unknown service '$SERVICE'" >&2; exit 2 ;;
 esac
 


### PR DESCRIPTION
## Problem

`./deploy-service recipes-bot <tag>` refuses the service:

```
deploy-service: refusing unknown service 'recipes-bot'
```

#78 wired `recipes-bot` into the compose stack (service definition, env template, restart handler) but missed the `deploy-service` allowlist — the same class of gap #79 fixed for the restart handler.

## Changes

Add `recipes-bot` to the `case "$SERVICE" in ...` allowlist in `ansible/roles/compose-up/files/deploy-service`.

## Verification

- `bash -n` on the script — passes